### PR TITLE
package.json: Unnecessary path property in ember-addon tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
     "url": "https://github.com/ngenworks/ember-cli-loading-slider.git"
   },
   "ember-addon": {
-    "paths": [
-      "."
-      ]
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Removal of the 'path' property as it slow down the startup time in seconds.
