### PR TITLE
Prevent failing when used in controllers without a route

### DIFF
--- a/app/mixins/loading-slider.js
+++ b/app/mixins/loading-slider.js
@@ -5,9 +5,11 @@ export default Ember.Mixin.create({
     loading: function() {
       var controller = this.controllerFor('application');
       controller.set('loading', true);
-      this.router.one('didTransition', function() {
-        controller.set('loading', false);
-      });
+      if( this.router ){
+        this.router.one('didTransition', function() {
+          controller.set('loading', false);
+        }); 
+      }
     },
     finished: function() {
       this.controllerFor('application').set('loading', false);


### PR DESCRIPTION
This commit adds a condition to validate whether the router is available before trying to use it. This allows us to extend the mixin in controllers that are not paired with a route.