### PR TITLE
Start the expanding animation immediately

### DIFF
--- a/app/components/loading-slider.js
+++ b/app/components/loading-slider.js
@@ -70,15 +70,16 @@ export default Ember.Component.extend({
         colorQueue = this.get('color');
 
     if ('object' === typeof colorQueue) {
-      var speedInterval = window.setInterval(function() {
+      (function updateFn() {
         var color = colorQueue.shift();
         colorQueue.push(color);
         self.expandItem.call(self, color);
         if ( ! self.get('isLoading')) {
-          window.clearInterval(speedInterval);
           outer.empty();
+        } else {
+          window.setTimeout(updateFn, speed);
         }
-      }, speed);
+      })();
     } else {
       this.expandItem.call(this, colorQueue, true);
     }


### PR DESCRIPTION
The expanding animation would start only after the first `speed` milliseconds have expired, after which it might already be too late for it to start (i.e. the action completes in less than `speed` milliseconds). Waiting for the animation to start once `isLoading` is detected to be true makes it feel very laggy too, especially when relying on the default speed (1000).

This PR changes the expanding animation to start immediately when `isLoading` changes to `true`.