### PR TITLE
Fix #14, trying to get width before didInsertElement()

### DIFF
--- a/app/components/loading-slider.js
+++ b/app/components/loading-slider.js
@@ -11,8 +11,6 @@ export default Ember.Component.extend({
     this.set('expanding', this.getAttr('expanding'));
     this.set('speed', this.getAttr('speed'));
     this.set('color', this.getAttr('color'));
-
-    this.manage();
   }),
 
   manage() {
@@ -130,5 +128,7 @@ export default Ember.Component.extend({
     if (color) {
       this.$('span').css('background-color', color);
     }
+
+    this.manage();
   }
 });


### PR DESCRIPTION
Fixes #14 error when `animate()` is trying to get width before `didInsertElement()`.