### PR TITLE
Stop expanding if component is destroyed

### DIFF
--- a/app/components/loading-slider.js
+++ b/app/components/loading-slider.js
@@ -125,6 +125,9 @@ export default Component.extend({
 
     if ('object' === typeof colorQueue) {
       (function updateFn() {
+        if (self.isDestroyed || self.isDestroying) {
+          return;
+        }
         let color = colorQueue.shift();
         colorQueue.push(color);
         self.expandItem.call(self, color);


### PR DESCRIPTION
This bug is causing an type error during acceptance testing, because in the following `expandItem()` method, `outer = this.$()` is null and `outerWidth = outer.width()` throws an error. Adding a check to `updateFn` solves the problem. If the component is destroyed or destroying, stop the expanding animation and do not call `expandItem`.