### PR TITLE
Adds Fastboot compatibility

### DIFF
--- a/app/components/loading-slider.js
+++ b/app/components/loading-slider.js
@@ -11,6 +11,9 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
+
+    if (isFastBoot()) { return; }
+
     run.once(this, function() {
       this.get('loadingSlider').on('startLoading', this, this._startLoading);
       this.get('loadingSlider').on('endLoading', this, this._endLoading);
@@ -19,6 +22,9 @@ export default Component.extend({
   },
 
   setAttrsThenManage: on('didReceiveAttrs', function() {
+
+    if (isFastBoot()) { return; }
+
     this.setProperties({
       isLoading: this.getAttr('isLoading'),
       duration: this.getAttr('duration'),
@@ -191,3 +197,7 @@ export default Component.extend({
     }
   }
 });
+
+function isFastBoot() {
+  return typeof FastBoot !== 'undefined';
+}


### PR DESCRIPTION
Ember CLI Loading Slider was throwing an error in Fastboot:

<img width="645" alt="screen shot 2017-02-28 at 16 01 37" src="https://cloud.githubusercontent.com/assets/2046935/23412990/3e3741f2-fdcf-11e6-9666-7d794b80344f.png">

This PR ensures the slider is only initialized in non-Fastboot environments.