### PR TITLE
Add a class to the internal span

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "4"
 
 sudo: false
 

--- a/app/components/loading-slider.js
+++ b/app/components/loading-slider.js
@@ -78,7 +78,7 @@ export default Component.extend({
     this.set('isLoaded', false);
     let self = this,
         elapsedTime = 0,
-        inner = $('<span>'),
+        inner = $('<span class="loading-slider__progress">'),
         outer = this.$(),
         duration = this.getWithDefault('duration', 300),
         innerWidth = 0,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.1.0",
     "ember-cli-htmlbars": "^1.0.1",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
     "ember-cli-ic-ajax": "0.2.4",
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-qunit": "^1.0.4",
@@ -43,7 +43,7 @@
     "progress"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5"
+    "ember-cli-babel": "^5.1.6"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
For styling purposes it is better to target classes than relying on nesting and tag names.

This change is non breaking, but will allow easier styling.