### PR TITLE
Allow users to specify a class for the progress bar

### DIFF
--- a/app/components/loading-slider.js
+++ b/app/components/loading-slider.js
@@ -6,6 +6,7 @@ export default Component.extend({
   tagName: 'div',
   classNames: ['loading-slider'],
   classNameBindings: 'expanding',
+  progressBarClass: null,
 
   loadingSlider: inject.service(),
 
@@ -78,7 +79,7 @@ export default Component.extend({
     this.set('isLoaded', false);
     let self = this,
         elapsedTime = 0,
-        inner = $('<span class="loading-slider__progress">'),
+        inner = $(`<span class="loading-slider__progress ${this.get('progressBarClass')}">`),
         outer = this.$(),
         duration = this.getWithDefault('duration', 300),
         innerWidth = 0,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": "https://github.com/jerel/ember-cli-loading-slider",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 4"
   },
   "author": "Jerel Unruh",
   "license": "MIT",


### PR DESCRIPTION
One last improvement, in case user want to customize the class of the progress bar without relying on cascading styles.