### PR TITLE
Fix stopping slider when transition is complete

### DIFF
--- a/app/mixins/loading-slider.js
+++ b/app/mixins/loading-slider.js
@@ -1,6 +1,7 @@
 import { inject as service } from '@ember/service';
 import Mixin from '@ember/object/mixin';
 import { isPresent } from '@ember/utils';
+import { getOwner }  from '@ember/application';
 
 export default Mixin.create({
   loadingSlider: service(),
@@ -9,8 +10,11 @@ export default Mixin.create({
     loading() {
       let loadingSliderService = this.get('loadingSlider');
       loadingSliderService.startLoading();
-      if (isPresent(this._router)) {
-        this._router.one('didTransition', function() {
+
+      let routerService = getOwner(this).lookup('service:router');
+      let router = routerService ? routerService._router : this._router;
+      if (isPresent(router)) {
+        router.one('didTransition', function() {
           loadingSliderService.endLoading();
         });
       }


### PR DESCRIPTION
The router service exists since Ember 2.15 so my fix should work for all versions this add-on supports except for 2.12 LTS.

I left `this._router` as a fallback. I'm not sure if it exists in some Ember versions (it was `undefined` in an Ember 2.18 app) but I didn't want to break something which might work.
