### PR TITLE
Support of actual Ember version

### DIFF
--- a/app/components/loading-slider.js
+++ b/app/components/loading-slider.js
@@ -41,6 +41,8 @@ export default Component.extend({
   },
 
   willDestroy() {
+    if (isFastBoot()) { return; }
+    
     run.once(this, function() {
       this.get('loadingSlider').off('startLoading', this, this._startLoading);
       this.get('loadingSlider').off('endLoading', this, this._endLoading);


### PR DESCRIPTION
My application based on Ember v3.11.
Without these changes, I get the following error:

There was an error running your app in fastboot. More info about the error:
 Error: Assertion Failed: You attempted to remove a function listener which did not exist on the instance, which means you may have attempted to remove it before it was added.
    at assert (/tmp/broccoli-30173tfmbJK6jIsw9/out-501-append_ember_auto_import_analyzer/assets/@ember/debug/index.js:163:1)
    at Meta.pushListener (/tmp/broccoli-30173tfmbJK6jIsw9/out-501-append_ember_auto_import_analyzer/assets/@ember/-internals/meta/lib/meta.js:542:1)
    at Meta.removeFromListeners (/tmp/broccoli-30173tfmbJK6jIsw9/out-501-append_ember_auto_import_analyzer/assets/@ember/-internals/meta/lib/meta.js:520:1)
    at removeListener (/tmp/broccoli-30173tfmbJK6jIsw9/out-501-append_ember_auto_import_analyzer/assets/@ember/-internals/metal.js:412:1)
    at Class.off (/tmp/broccoli-30173tfmbJK6jIsw9/out-501-append_ember_auto_import_analyzer/assets/@ember/-internals/runtime/lib/mixins/evented.js:123:1)
    at Class.<anonymous> (/tmp/broccoli-30173tfmbJK6jIsw9/out-501-append_ember_auto_import_analyzer/assets/project/components/loading-slider.js:49:1)
    at invokeWithOnError (/tmp/broccoli-30173tfmbJK6jIsw9/out-501-append_ember_auto_import_analyzer/assets/backburner.js:344:1)
    at Queue.flush (/tmp/broccoli-30173tfmbJK6jIsw9/out-501-append_ember_auto_import_analyzer/assets/backburner.js:226:1)
    at DeferredActionQueues.flush (/tmp/broccoli-30173tfmbJK6jIsw9/out-501-append_ember_auto_import_analyzer/assets/backburner.js:423:1)
    at Backburner._end (/tmp/broccoli-30173tfmbJK6jIsw9/out-501-append_ember_auto_import_analyzer/assets/backburner.js:957:1)
    at Backburner._boundAutorunEnd (/tmp/broccoli-30173tfmbJK6jIsw9/out-501-append_ember_auto_import_analyzer/assets/backburner.js:626:1)
    at process._tickCallback (internal/process/next_tick.js:68:7)